### PR TITLE
Lock Hubot to fix broken tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "chai": ">=1.9.2 <3",
     "mocha": "~2.2.5",
+    "hubot": "< 2.14.0",
     "hubot-test-helper": "0.0.2"
   },
 

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   "devDependencies": {
     "chai": ">=1.9.2 <3",
     "mocha": "~2.2.5",
-    "hubot": "< 2.14.0",
-    "hubot-test-helper": "0.0.2"
+    "hubot-test-helper": "0.0.7"
   },
 
   "main": "index.coffee"

--- a/test/graph-me_test.coffee
+++ b/test/graph-me_test.coffee
@@ -35,7 +35,7 @@ describe "graph-me", () ->
     process.env["HUBOT_GRAPHITE_S3_BUCKET"] = "bucket"
     process.env["HUBOT_GRAPHITE_S3_ACCESS_KEY_ID"] = "access_key_id"
     process.env["HUBOT_GRAPHITE_S3_SECRET_ACCESS_KEY"] = "secret_access_key"
-    room = helper.createRoom()
+    room = helper.createRoom(httpd: false)
 
   # -----------------------------------------------------
 


### PR DESCRIPTION
The changes in Hubot 2.14.0 seem to have broken some of the tests. I think the problem is with hubot-test-helper, but for now we should lock Hubot below 2.14.0 to keep the tests green. Eventually, the tests and/or supporting libraries should be fixed to make the tests green again.
